### PR TITLE
Dev orderbook

### DIFF
--- a/deploy/01-clearing-house-config.ts
+++ b/deploy/01-clearing-house-config.ts
@@ -1,20 +1,32 @@
-import { ethers, network, upgrades } from "hardhat"
+import { network } from "hardhat"
 import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { HARDHAT_CHAINID, isDevelopmentChain } from "../helper.hardhat.config"
 import { verify } from "../scripts/verify"
 
 const deploy = async (hre: HardhatRuntimeEnvironment) => {
-    const { log } = hre.deployments
+    const { log, deploy } = hre.deployments
+    const { deployer } = await hre.getNamedAccounts()
     const chainId = network.config.chainId || HARDHAT_CHAINID
 
     log("#########################")
     log(`# Deploying ClearingHouseConfig Contract to: ${chainId} ...`)
 
-    const ClearingHouseConfigFactory = await ethers.getContractFactory("ClearingHouseConfig")
-    const clearingHouseConfigContract = await upgrades.deployProxy(ClearingHouseConfigFactory, [], {
-        initializer: "initialize",
+    const clearingHouseConfigContract = await deploy("ClearingHouseConfig", {
+        from: deployer,
+        args: [],
+        log: true,
+        proxy: {
+            owner: deployer,
+            proxyContract: "OpenZeppelinTransparentProxy",
+            execute: {
+                init: {
+                    methodName: "initialize",
+                    args: [],
+                },
+            },
+        },
     })
-    await clearingHouseConfigContract.deployed()
+
     log("# ClearingHouseConfig contract deployed at address:", clearingHouseConfigContract.address)
     log("#########################")
 
@@ -24,4 +36,4 @@ const deploy = async (hre: HardhatRuntimeEnvironment) => {
 }
 
 export default deploy
-deploy.tags = ["all"]
+deploy.tags = ["clearingconfig", "all"]

--- a/deploy/02-insurance-fund.ts
+++ b/deploy/02-insurance-fund.ts
@@ -1,42 +1,50 @@
-import { ethers, network, upgrades } from "hardhat"
+import { ethers, network } from "hardhat"
 import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { HARDHAT_CHAINID, isDevelopmentChain, networkConfigHelper } from "../helper.hardhat.config"
 import { verify } from "../scripts/verify"
 import { TestERC20 } from "../typechain"
 
 const deploy = async (hre: HardhatRuntimeEnvironment) => {
-    const { log } = hre.deployments
+    const { log, deploy } = hre.deployments
+    const { deployer } = await hre.getNamedAccounts()
     const chainId = network.config.chainId || HARDHAT_CHAINID
     let usdcAddress
     log("#########################")
     log(`# Deploying InsuranceFund Contract to: ${chainId} ...`)
 
     if (isDevelopmentChain(chainId)) {
-        usdcAddress = (await deployUSDCToken()).address
+        const tokenFactory = await ethers.getContractFactory("TestERC20")
+        const USDC = (await tokenFactory.deploy()) as TestERC20
+        await USDC.__TestERC20_init("TestUSDC", "USDC", 6)
+        usdcAddress = USDC.address
         log(`# Deployed TestUSDC Token to: ${usdcAddress}`)
     } else {
         usdcAddress = networkConfigHelper[chainId].usdc
     }
 
-    const insuranceFundFactory = await ethers.getContractFactory("InsuranceFund")
-    const insuranceFundContract = await upgrades.deployProxy(insuranceFundFactory, [usdcAddress], {
-        initializer: "initialize",
+    const insuranceFundContract = await deploy("InsuranceFund", {
+        from: deployer,
+        args: [],
+        log: true,
+        proxy: {
+            owner: deployer,
+            proxyContract: "OpenZeppelinTransparentProxy",
+            execute: {
+                init: {
+                    methodName: "initialize",
+                    args: [usdcAddress],
+                },
+            },
+        },
     })
-    await insuranceFundContract.deployed()
+
     log("# InsuranceFund contract deployed at address:", insuranceFundContract.address)
     log("#########################")
 
     if (!isDevelopmentChain(chainId)) {
-        verify(insuranceFundContract.address, [])
+        verify(insuranceFundContract.address, [usdcAddress])
     }
 }
 
 export default deploy
 deploy.tags = ["all"]
-
-async function deployUSDCToken() {
-    const tokenFactory = await ethers.getContractFactory("TestERC20")
-    const USDC = (await tokenFactory.deploy()) as TestERC20
-    await USDC.__TestERC20_init("TestUSDC", "USDC", 6)
-    return USDC
-}

--- a/deploy/02-market-registry.ts
+++ b/deploy/02-market-registry.ts
@@ -1,0 +1,79 @@
+import { Contract } from "ethers"
+import { ethers, network, upgrades } from "hardhat"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { HARDHAT_CHAINID, isDevelopmentChain, networkConfigHelper } from "../helper.hardhat.config"
+import { verify } from "../scripts/verify"
+
+// 2. MarketRegistry -> uniV3Factory.address & quoteToken.address
+//    2.1. For each market, we deploy a pair of two virtual tokens (with no real value) and initiate a new Uniswap V3 pool to provide liquidity to.
+//       2.1.1. Base token: the virtual underlying asset users are trading for, such as vETH, vBTC
+//       2.1.2. Quote token: the counter currency of base token, which is always vUSDC for any base token
+const deploy = async (hre: HardhatRuntimeEnvironment) => {
+    const { log, get } = hre.deployments
+    const chainId = network.config.chainId || HARDHAT_CHAINID
+    // let aggregatorFactory;
+    // let chainlinkPriceFeedV3Factory;
+    // log("#########################")
+    // log(`# Deploying MarketRegistry Contract to: ${chainId} ...`)
+    // log("# Deploying AggregatorV3...")
+
+    // if (isDevelopmentChain(chainId)) {
+    //     aggregatorFactory = await ethers.getContractFactory('TestAggregatorV3');
+    // } else {
+    //     aggregatorFactory = await ethers.getContractFactory('AggregatorV3Interface');
+    // }
+    // const aggregator = await aggregatorFactory.deploy()
+    // log(`# Deployed at address: ${aggregator.address}}`);
+
+    // log("# Deploying ChainlinkPriceFeedV3...")
+
+    // if (isDevelopmentChain(chainId)) {
+    //     chainlinkPriceFeedV3Factory = await ethers.getContractFactory('TestChainlinkPriceFeed');
+    // } else {
+    //     chainlinkPriceFeedV3Factory = await ethers.getContractFactory('ChainlinkPriceFeedV3');
+    // }
+
+    // const chainlinkPriceFeedV3 = await chainlinkPriceFeedV3Factory.deploy(
+    //     aggregator.address,
+    //     40 * 60, // 40 mins
+    //     CACHED_TWAP_INTERVAL,
+    // )
+
+    const usdcAddress = await deployQuoteToken(chainId)
+    const uniV3Factory = await deployUniswapV3Factory()
+
+    const marketRegistryFactory = await ethers.getContractFactory("MarketRegistry")
+    const marketRegistryContract = await upgrades.deployProxy(
+        marketRegistryFactory,
+        [uniV3Factory.address, usdcAddress],
+        {
+            initializer: "initialize",
+        },
+    )
+    await marketRegistryContract.deployed()
+    log("# MarketRegistry contract deployed at address:", marketRegistryContract.address)
+    log("#########################")
+
+    if (!isDevelopmentChain(chainId)) {
+        verify(marketRegistryContract.address, [])
+    }
+}
+
+export default deploy
+deploy.tags = ["marketreg", "all"]
+
+async function deployQuoteToken(chainId: number) {
+    if (isDevelopmentChain(chainId)) {
+        const quoteTokenFactory = await ethers.getContractFactory("QuoteToken")
+        const quoteToken = await quoteTokenFactory.deploy() // as QuoteToken
+        await quoteToken.initialize("TestUSDC", "USDC")
+        networkConfigHelper[chainId].usdc = quoteToken.address
+    }
+
+    return networkConfigHelper[chainId].usdc
+}
+
+async function deployUniswapV3Factory(): Promise<Contract> {
+    const factoryFactory = await ethers.getContractFactory("UniswapV3Factory")
+    return await factoryFactory.deploy() // as UniswapV3Factory
+}

--- a/deploy/04-orderbook.ts
+++ b/deploy/04-orderbook.ts
@@ -1,0 +1,39 @@
+import { network } from "hardhat"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { HARDHAT_CHAINID, isDevelopmentChain } from "../helper.hardhat.config"
+import { verify } from "../scripts/verify"
+
+const deploy = async (hre: HardhatRuntimeEnvironment) => {
+    const { log, get, deploy } = hre.deployments
+    const { deployer } = await hre.getNamedAccounts()
+    const chainId = network.config.chainId || HARDHAT_CHAINID
+    log("#########################")
+    log(`# Deploying Orderbook Contract to: ${chainId} ...`)
+
+    const marketRegistry = await get("MarketRegistry")
+    const orderbookContract = await deploy("OrderBook", {
+        from: deployer,
+        args: [],
+        log: true,
+        proxy: {
+            owner: deployer,
+            proxyContract: "OpenZeppelinTransparentProxy",
+            execute: {
+                init: {
+                    methodName: "initialize",
+                    args: [marketRegistry.address],
+                },
+            },
+        },
+    })
+    log("# Orderbook contract deployed at address:", orderbookContract.address)
+    log("#########################")
+
+    if (!isDevelopmentChain(chainId)) {
+        verify(orderbookContract.address, [])
+    }
+}
+
+export default deploy
+deploy.tags = ["orderbook", "all"]
+deploy.dependencies = ["marketreg"]

--- a/hardhat-deployment.md
+++ b/hardhat-deployment.md
@@ -1,0 +1,51 @@
+# Contract deployment order
+
+### Boilerplate contracts
+
+1. Deploy 2 virtual tokens -> BaseToken.sol & QuoteToken.sol
+2. Deploy ERC20 Token `const USDC = (await tokenFactory.deploy()) as TestERC20``
+3. Deploy UniswapV3Factory then create a pool 
+4. `await uniV3Factory.createPool(baseToken.address, quoteToken.address, uniFeeTier)`` /* uniFeeTier = 10000, // 1% */
+
+
+### Protocol contracts
+
+1. ClearingHouseConfig -> no arguments
+2. MarketRegistry -> uniV3Factory.address & quoteToken.address
+   2.1. For each market, we deploy a pair of two virtual tokens (with no real value) and initiate a new Uniswap V3 pool to provide liquidity to.
+      2.1.1. Base token: the virtual underlying asset users are trading for, such as vETH, vBTC
+      2.1.2. Quote token: the counter currency of base token, which is always vUSDC for any base token
+3. OrderBook -> (marketRegistry.address)
+4. InsuranceFund -> (USDC.address)
+5. Exchange -> (
+		marketRegistry.address, 
+		orderBook.address,
+		clearingHouseConfig.address
+	)
+6. AccountBalance -> (clearingHouseConfig.address, orderbook.address)
+7. Vault -> (
+		insuranceFund.address,
+    clearingHouseConfig.address,
+    accountBalance.address,
+    exchange.address,
+   )
+8. CollateralManager -> (
+		clearingHouseConfig.address,
+    vault.address,
+    5, // maxCollateralTokensPerAccount
+    "750000", // debtNonSettlementTokenValueRatio
+    "500000", // liquidationRatio
+    "2000", // mmRatioBuffer
+    "30000", // clInsuranceFundFeeRatio
+    parseUnits("10000", usdcDecimals), // debtThreshold
+    parseUnits("500", usdcDecimals), // collateralValueDust
+	)
+9.  ClearingHouse -> (
+			clearingHouseConfig.address,
+      vault.address,
+      quoteToken.address,
+      uniV3Factory.address,
+      exchange.address,
+      accountBalance.address,
+      insuranceFund.address
+	)

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -4,7 +4,7 @@ import "@openzeppelin/hardhat-upgrades"
 import "@typechain/hardhat"
 import "hardhat-contract-sizer"
 import "hardhat-dependency-compiler"
-import 'hardhat-deploy'
+import "hardhat-deploy"
 import "hardhat-gas-reporter"
 import { HardhatUserConfig } from "hardhat/config"
 import "solidity-coverage"
@@ -55,6 +55,11 @@ const config: HardhatUserConfig = {
         jobs: 4,
         timeout: 120000,
         color: true,
+    },
+    namedAccounts: {
+        deployer: {
+            default: 0,
+        },
     },
 }
 

--- a/helper.hardhat.config.ts
+++ b/helper.hardhat.config.ts
@@ -1,16 +1,30 @@
 export const HARDHAT_CHAINID = 31337
 export const GOERLI_CHAINID = 5
 
+interface ContractArguments {
+    name: string
+    usdc?: string
+}
 interface ConfigHelper {
-    [key: number]: any
+    [chainId: number]: ContractArguments
 }
 
 export const networkConfigHelper: ConfigHelper = {
     5: {
         name: "goerli",
+        usdc: "",
+    },
+    10: {
+        name: "optimism mainnet",
+        usdc: "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+    },
+    420: {
+        name: "Optimism Goerli Testnet",
+        usdc: "0x5f1C3c9D42F531975EdB397fD4a34754cc8D3b71",
     },
     31337: {
         name: "hardhat",
+        usdc: "",
     },
 }
 

--- a/helper.hardhat.config.ts
+++ b/helper.hardhat.config.ts
@@ -4,6 +4,8 @@ export const GOERLI_CHAINID = 5
 interface ContractArguments {
     name: string
     usdc?: string
+    veth?: string
+    ethusdPriceFeed?: string
 }
 interface ConfigHelper {
     [chainId: number]: ContractArguments
@@ -13,18 +15,23 @@ export const networkConfigHelper: ConfigHelper = {
     5: {
         name: "goerli",
         usdc: "",
+        ethusdPriceFeed: "",
     },
     10: {
         name: "optimism mainnet",
         usdc: "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+        ethusdPriceFeed: "0x13e3Ee699D1909E989722E753853AE30b17e08c5",
     },
     420: {
         name: "Optimism Goerli Testnet",
         usdc: "0x5f1C3c9D42F531975EdB397fD4a34754cc8D3b71",
+        ethusdPriceFeed: "0x57241A37733983F97C4Ab06448F244A1E0Ca0ba8",
     },
     31337: {
         name: "hardhat",
         usdc: "",
+        ethusdPriceFeed: "",
+        veth: "",
     },
 }
 


### PR DESCRIPTION
This PR contains a couple of things:

1. Some refactors, insead of using ethers & upgrades to deploy `upgradable contracts` I think is better to use the `deploy` from the `hre` (hardhat runtime environment). With that the dependencies between contracts works, for example when we deploy the `OrderBook` the get functions form `hre` finds the `MarketRegistry` deployment, with ethers I couldnt make it work.
2. Implementation fo the OrderBook contract with MarketRegistry dependency 